### PR TITLE
Check if window scope is available before accessing getComputedStyle

### DIFF
--- a/src/devicon-react-svg.js
+++ b/src/devicon-react-svg.js
@@ -19,7 +19,7 @@ class DevIcon extends Component {
         this.setStrokeColor = this.setStrokeColor.bind(this);
     }
     setStrokeColor (thisComponent) {
-        const computedFill = getComputedStyle(thisComponent).fill;
+        const computedFill = typeof window !== undefined && getComputedStyle(thisComponent).fill;
         this.setState({
             strokeColor: computedFill,
         })


### PR DESCRIPTION
This will solve the following issue:
![image](https://user-images.githubusercontent.com/20082141/99918363-9bb82880-2d16-11eb-86da-42ab2528099e.png)

![image](https://user-images.githubusercontent.com/20082141/99918369-a1ae0980-2d16-11eb-8bbf-ec5ec8fe792a.png)
